### PR TITLE
Set default memory to 1024 MB and number of CPUs to 1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,11 @@ Vagrant.configure('2') do |config|
   config.vm.network :forwarded_port, guest: 3000, host: 3000
   #config.vm.network :forwarded_port, guest: 9200, host: 9200
 
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+    v.cpus = 1
+  end
+
   config.vm.provision :shell, path: 'bootstrap/bootstrap.sh', keep_color: true
   config.vm.provision :shell, path: "bootstrap/install-rvm.sh", args: "stable", privileged: false
   config.vm.provision :shell, path: "bootstrap/install-ruby.sh", args: "2.2.1 ", privileged: false


### PR DESCRIPTION
Spent some time today trying to build the project but gave up now due to rail-assets being dead for almost 1 hour (see #25).

Previously, I was having the following problem. When running bundle, it was always stop immediately after printing that it was installing nokogiri. Here's the console output.

```
Installing rails_stdout_logging 0.0.4
Installing rails_layout 1.0.29
Installing redcarpet 3.3.3 with native extensions
Installing sass 3.4.19
Installing spring 1.4.4
Installing tzinfo 1.2.2
Installing nokogiri 1.6.6.4 with native extensions
Killed
```

The problem persisted even after rebooting the VM. Googling I found someone suggesting to increase the VM memory (source https://forum.linode.com/viewtopic.php?t=7897%3E). Had a look, and it was using the default setting which creates a 512MB instance. 

I couldn't run the nokogiri now due to #25, but I believe this should fix the bundle process being killed, and 1GB is an OK size for a developer box I think. We are using 2GB for a Vagrant VM for maps.nzoss.org.nz, which runs Postgres + PostGIS + mapserver + nginx (https://github.com/kinow/nz-osm-server/blob/2d6e8069e47a34958f06f129ce5ff37fd07b7bd2/infra/Vagrantfile#L49).