### PR TITLE
Remove therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,6 @@ source 'https://rubygems.org' do
   end
 
   group :assets do
-    gem 'therubyracer'
     gem 'coffee-rails'
   end
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ source 'https://rubygems.org' do
   gem 'newrelic_rpm'
 
   gem 'sass-rails'
-  gem 'less-rails'
   gem "twitter-bootstrap-rails"
 
   group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,6 @@ GEM
       less (~> 2.6.0)
       sprockets (> 2, < 4)
       tilt
-    libv8 (3.16.14.13)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -240,7 +239,6 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.3)
-    ref (2.0.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
     rspec (3.4.0)
@@ -293,9 +291,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
-      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
@@ -366,7 +361,6 @@ DEPENDENCIES
   selenium-webdriver!
   simple_form!
   spring!
-  therubyracer!
   turbolinks!
   twitter-bootstrap-rails!
   uglifier (>= 1.3.0)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,7 +344,6 @@ DEPENDENCIES
   jquery-rails!
   kaminari (= 0.14.1)!
   leaflet-rails!
-  less-rails!
   newrelic_rpm!
   pg!
   pry-rails!


### PR DESCRIPTION
> “[therubyracer is] no longer required and strongly discouraged as [it] uses a very large amount of memory. A version of Node is installed by the Ruby buildpack that will be used to compile your assets.
